### PR TITLE
Fix a RuboCop offense

### DIFF
--- a/rubocop-sequel.gemspec
+++ b/rubocop-sequel.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ['Timothée Peignier']
   gem.email         = ['timothee.peignier@tryphon.org']
   gem.description   = 'Code style checking for Sequel'
-  gem.summary       = 'A Sequel plugin for the RuboCop code style & linting tool.'
+  gem.summary       = 'A Sequel plugin for RuboCop'
   gem.homepage      = 'https://github.com/rubocop-hq/rubocop-sequel'
   gem.license       = 'MIT'
 


### PR DESCRIPTION
This PR fixes a RuboCop offense.

```console
% bundle exec rubocop --parallel
Inspecting 15 files
C..............

Offenses:

rubocop-sequel.gemspec:7:81: C: Metrics/LineLength: Line is too long. [82/80]
  gem.summary       = 'A Sequel plugin for the RuboCop code style & linting tool.'
                                                                                ^^

15 files inspected, 1 offense detected
```

https://travis-ci.org/rubocop-hq/rubocop-sequel/jobs/393013658#L492-L505