### PR TITLE
Build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+
+steps: &steps
+  steps:
+    - checkout
+    - run: bundle install
+    - run: bundle exec rubocop --parallel
+    - run: bundle exec rspec
+
+jobs:
+  ruby-2-3:
+    docker:
+      - image: circleci/ruby:2.3
+    <<: *steps
+
+  ruby-2-4:
+    docker:
+      - image: circleci/ruby:2.4
+    <<: *steps
+
+  ruby-2-5:
+    docker:
+      - image: circleci/ruby:2.5
+    <<: *steps
+
+workflows:
+  build:
+    jobs:
+      - ruby-2-3
+      - ruby-2-4
+      - ruby-2-5

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI status](https://circleci.com/gh/rubocop-hq/rubocop-sequel.svg?style=svg)](https://circleci.com/gh/rubocop-hq/rubocop-sequel)
+
 # RuboCop Sequel
 
 Code style checking for [Sequel](https://sequel.jeremyevans.net/).


### PR DESCRIPTION
The rest of the rubocop-hq projects have moved from Travis to CircleCI. While not strictly necessary, it might be convenient to have also this project running on Circle.

Travis build finished in [70 seconds](https://travis-ci.org/rubocop-hq/rubocop-sequel/builds/472570742).
Circle build finished in [15 seconds](https://circleci.com/workflow-run/06217c6d-2faf-4cdb-b768-968c2eac43fe).

In a follow-up PR I will remove the Travis configuration.