### PR TITLE
Bump rubocop version to 1.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/rubocop/cop/sequel/concurrent_index.rb
+++ b/lib/rubocop/cop/sequel/concurrent_index.rb
@@ -13,9 +13,7 @@ module RuboCop
 
         def on_send(node)
           indexes?(node) do |args|
-            if offensive?(args)
-              add_offense(node, location: :selector, message: MSG)
-            end
+            add_offense(node, location: :selector, message: MSG) if offensive?(args)
           end
         end
 

--- a/rubocop-sequel.gemspec
+++ b/rubocop-sequel.gemspec
@@ -13,13 +13,13 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'rubocop-sequel'
   gem.require_paths = ['lib']
-  gem.version       = '0.0.6'
+  gem.version       = '0.1.0'
 
-  gem.add_runtime_dependency 'rubocop', '~> 0.55', '>= 0.55'
+  gem.add_runtime_dependency 'rubocop', '~> 1.0', '>= 1.0.0'
 
   gem.add_development_dependency 'rake', '~> 12.3.0', '>= 12.0.0'
   gem.add_development_dependency 'rspec', '~> 3.7', '>= 3.7.0'
-  gem.add_development_dependency 'rubocop-rspec', '~> 1.25.0', '>= 1.25.0'
+  #  gem.add_development_dependency 'rubocop-rspec', '~> 2.0', '>= 2.0.0'
   gem.add_development_dependency 'sequel', '~> 4.49', '>= 4.49.0'
   gem.add_development_dependency 'simplecov', '~> 0.16'
   gem.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.12'

--- a/rubocop-sequel.gemspec
+++ b/rubocop-sequel.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '~> 2.4'
 
-  gem.add_runtime_dependency 'rubocop', '~> 1.0', '>= 1.0.0'
+  gem.add_runtime_dependency 'rubocop', '~> 1.0'
 
-  gem.add_development_dependency 'rake', '~> 12.3.0', '>= 12.0.0'
-  gem.add_development_dependency 'rspec', '~> 3.7', '>= 3.7.0'
-  gem.add_development_dependency 'rubocop-rspec', '~> 2.0', '>= 2.0.0'
-  gem.add_development_dependency 'sequel', '~> 4.49', '>= 4.49.0'
+  gem.add_development_dependency 'rake', '~> 12.3.0'
+  gem.add_development_dependency 'rspec', '~> 3.7'
+  gem.add_development_dependency 'rubocop-rspec', '~> 2.0'
+  gem.add_development_dependency 'sequel', '~> 4.49'
   gem.add_development_dependency 'simplecov', '~> 0.16'
   gem.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.12'
 end

--- a/rubocop-sequel.gemspec
+++ b/rubocop-sequel.gemspec
@@ -15,11 +15,13 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = '0.1.0'
 
+  gem.required_ruby_version = '~> 2.4'
+
   gem.add_runtime_dependency 'rubocop', '~> 1.0', '>= 1.0.0'
 
   gem.add_development_dependency 'rake', '~> 12.3.0', '>= 12.0.0'
   gem.add_development_dependency 'rspec', '~> 3.7', '>= 3.7.0'
-  #  gem.add_development_dependency 'rubocop-rspec', '~> 2.0', '>= 2.0.0'
+  gem.add_development_dependency 'rubocop-rspec', '~> 2.0', '>= 2.0.0'
   gem.add_development_dependency 'sequel', '~> 4.49', '>= 4.49.0'
   gem.add_development_dependency 'simplecov', '~> 0.16'
   gem.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.12'


### PR DESCRIPTION
Ref #12 

rubocop-rspec is still tied to < 1.0; this should be reinstated once v2.0 is released. See rubocop-hq/rubocop-rspec#1055

All the tests still pass, so I hope this will still work...!